### PR TITLE
Extension[Element] pydantic type validation fix

### DIFF
--- a/aidbox/base/__init__.py
+++ b/aidbox/base/__init__.py
@@ -288,7 +288,7 @@ class Extension(Element):
     valueUri: Optional[str] = None
     valueUsageContext: Optional[UsageContext] = None
     valueTime: Optional[str] = None
-    valueDecimal: Optional[str] = None
+    valueDecimal: Optional[float] = None
     valueCanonical: Optional[str] = None
     valueMarkdown: Optional[str] = None
     valueIdentifier: Optional[Identifier] = None


### PR DESCRIPTION
This is a fix regarding valueDecimal under Extension element. It's actually a float object which is being represented as string